### PR TITLE
Repository and key updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           - ubuntu2004
           - ubuntu2204
           - centos7
-        version: [12, 13, 14, 15, 16]
+        version: [12, 13, 14, 15]
 
     steps:
       - name: Check out the Repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           - ubuntu2004
           - ubuntu2204
           - centos7
-        version: [11, 12, 13, 14, 15]
+        version: [12, 13, 14, 15, 16]
 
     steps:
       - name: Check out the Repository

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -158,7 +158,7 @@ postgresql_krb_caseins_users: off
 
 # - SSL -
 
-postgresql_ssl: off
+postgresql_ssl: false
 postgresql_ssl_ciphers:
   - "HIGH"
   - "MEDIUM"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -839,7 +839,8 @@ postgresql_install_repository: true
 # APT settings
 postgresql_apt_key_id: "ACCC4CF8"
 postgresql_apt_key_url: "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
-postgresql_apt_repository: "deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main {{ postgresql_version }}"
+postgresql_apt_repository: "deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main"
+
 # Pin-Priority of PGDG repository
 postgresql_apt_pin_priority: 500
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -844,12 +844,14 @@ postgresql_apt_repository: "deb http://apt.postgresql.org/pub/repos/apt/ {{ ansi
 postgresql_apt_pin_priority: 500
 
 # YUM repository locations
-postgresql_yum_repository_url: "http://yum.postgresql.org"
-postgresql_pgdg_repository_url: "https://download.postgresql.org/pub/repos/yum/"
+postgresql_yum_repository_url: "https://download.postgresql.org/pub/repos/yum"
+postgresql_pgdg_repository_url: "https://download.postgresql.org/pub/repos/yum/keys"
+
 
 # YUM (RedHat, CentOS, etc.) baseurl/gpgkey
 postgresql_yum_repository_baseurl: "{{ postgresql_yum_repository_url }}/{{ postgresql_version }}/{{ ansible_os_family | lower }}/rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}"
-postgresql_yum_repository_gpgkey: "{{ postgresql_pgdg_repository_url }}/RPM-GPG-KEY-PGDG-{{ postgresql_version_terse }}"
+postgresql_yum_repository_gpgkey: "{{ postgresql_pgdg_repository_url }}/PGDG-RPM-GPG-KEY-RHEL7"
+
 
 # DNF (Fedora) baseurl/gpgkey
 postgresql_dnf_repository_baseurl: "{{ postgresql_yum_repository_url }}/{{ postgresql_version }}/fedora/fedora-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -16,12 +16,6 @@
           changed_when: false
           when: ansible_os_family == "Debian"
 
-        - name: Install gpg-agent
-          apt:
-            name: gpg-agent
-            state: present
-          when: ansible_os_family == "Debian"
-
   roles:
     - role: ansible-postgresql
       tags:

--- a/tasks/install_apt.yml
+++ b/tasks/install_apt.yml
@@ -8,11 +8,19 @@
     state: present
 
 - name: PostgreSQL | Add PostgreSQL repository apt-key | apt
-  apt_key:
-    id: "{{ postgresql_apt_key_id }}"
+  get_url:
     url: "{{ postgresql_apt_key_url }}"
-    state: present
+    dest: "/etc/apt/trusted.gpg.d/{{ postgresql_apt_key_id }}.asc"
+    mode: '0644'
+    force: true
   when: postgresql_apt_key_url and postgresql_apt_key_id and postgresql_install_repository
+
+# - name: PostgreSQL | Add PostgreSQL repository apt-key | apt
+#   apt_key:
+#     id: "{{ postgresql_apt_key_id }}"
+#     url: "{{ postgresql_apt_key_url }}"
+#     state: present
+#   when: postgresql_apt_key_url and postgresql_apt_key_id and postgresql_install_repository
 
 - name: PostgreSQL | Add PostgreSQL repository | apt
   apt_repository:

--- a/tasks/install_yum.yml
+++ b/tasks/install_yum.yml
@@ -16,7 +16,7 @@
            baseurl: "{{ postgresql_yum_repository_baseurl }}"
            gpgkey: "{{ postgresql_yum_repository_gpgkey }}"
         when: postgresql_install_repository
-        
+
       - name: PostgreSQL | Make sure the dependencies are installed | yum
         yum:
          name: ["python-psycopg2", "python-pycurl", "glibc-common","libselinux-python"]


### PR DESCRIPTION
This PR corrects three issues;

1. Install on Centos7 Failed, GPG key and repository URLs updated recently, updated variables in `defaults/main.yml`
```
TASK [ansible-postgresql : PostgreSQL | Install PostgreSQL | yum] **************
fatal: [instance]: FAILED! => {"changed": false, "changes": {"installed": ["postgresql12-server", "postgresql12", "postgresql12-contrib"]}, "msg": "warning: /var/cache/yum/x86_64/7/postgresql/packages/postgresql12-12.17-1PGDG.rhel7.x86_64.rpm: Header V4 RSA/SHA1 Signature, key ID 73e3b907: NOKEY\n\n\nGPG key retrieval failed: [Errno 14] HTTPS Error 404 - Not Found\n",
...
```
2. Install on Ubuntu, apt-key is installed using deprecated method, causing the following warning on `apt update`; 
```
W: http://apt.postgresql.org/pub/repos/apt/dists/jammy-pgdg/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
```
Solution:  now using `get_url` module to install apt-key in `/etc/apt/trusted.gpg.d`    [Reference](https://github.com/ansible/ansible/issues/78063)

NOTE:  ansible module `deb822_repository` can install repository and apt key in one step, however it requires ansible 2.15

3.  when postgresql is installed with pgbouncer via role [miarec/ansible-role-pgbouncer](https://github.com/miarec/ansible-role-pgbouncer) , duplicate repositories are installed,,  example `deb http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main 12`. This role installs version specific repository, and pgbouncer install a generic version,  this causes the following warnings on `apt-update`
```
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list.d/apt_postgresql_org_pub_repos_apt.list:1 and /etc/apt/sources.list.d/apt_postgresql_org_pub_repos_apt.list:2
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list.d/apt_postgresql_org_pub_repos_apt.list:1 and /etc/apt/sources.list.d/apt_postgresql_org_pub_repos_apt.list:2
W: Target Translations (main/i18n/Translation-en) is configured multiple times in /etc/apt/sources.list.d/apt_postgresql_org_pub_repos_apt.list:1 and /etc/apt/sources.list.d/apt_postgresql_org_pub_repos_apt.list:2
W: Target CNF (main/cnf/Commands-amd64) is configured multiple times in /etc/apt/sources.list.d/apt_postgresql_org_pub_repos_apt.list:1 and /etc/apt/sources.list.d/apt_postgresql_org_pub_repos_apt.list:2
W: Target CNF (main/cnf/Commands-all) is configured multiple times in /etc/apt/sources.list.d/apt_postgresql_org_pub_repos_apt.list:1 and /etc/apt/sources.list.d/apt_postgresql_org_pub_repos_apt.list:2
```
Solution: updated variable `postgresql_apt_repository` to install generic repository.